### PR TITLE
Fix for translation framework

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -50,7 +50,7 @@ addon_info = {
 # pythonSources = ["addon/globalPlugins/*.py"]
 # For more information on SCons Glob expressions please take a look at:
 # https://scons.org/doc/production/HTML/scons-user/apd.html
-pythonSources = ["addon/globalPlugins/directLink.py"]
+pythonSources = ["addon/globalPlugins/DirectLink.py"]
 
 # Files that contain strings for translation. Usually your python sources
 i18nSources = pythonSources + ["buildVars.py"]


### PR DESCRIPTION
Issue:
On SVN screenreader translation (translation framework), there are only 2 string to translate whereas there are more in the add-on.

Cause:
There was a case issue in the translatable files with `DirectLink.py`.
Translation framework runs on Linux, thus it is case sensitive.

